### PR TITLE
[WIP] Post-Releaseワークフローを設定する

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,22 @@
+name: Post-Release
+
+on: push
+
+jobs:
+  test:
+    name: post-process to Release
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: npm install, doc, publish-docs
+      run: |
+        npm ci
+        npm run doc
+        npx gh-pages -d docs -r https://${{ secrets.GITHUB_TOKEN }}@github.com/maboroshi-inc/selector.git
+      env:
+        CI: true

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -17,6 +17,6 @@ jobs:
       run: |
         npm ci
         npm run doc
-        npx gh-pages -d docs -u "haribote <haribote.nobody@gmail.com>" -r "https://${{ secrets.GITHUB_TOKEN }}@github.com/maboroshi-inc/selector.git"
+        npx gh-pages -d docs -r https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
       env:
         CI: true

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -17,6 +17,6 @@ jobs:
       run: |
         npm ci
         npm run doc
-        npx gh-pages -d docs -r https://${{ secrets.GITHUB_TOKEN }}@github.com/maboroshi-inc/selector.git
+        npx gh-pages -d docs -r https://${{ secrets.GITHUB_TOKEN }}@github.com/maboroshi-inc/selector.git -u "haribote <haribote.nobody@gmail.com>"
       env:
         CI: true

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -17,6 +17,6 @@ jobs:
       run: |
         npm ci
         npm run doc
-        npx gh-pages -d docs -r https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+        npx gh-pages -d docs -u "haribote <haribote.nobody@gmail.com>"  -r https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
       env:
         CI: true

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -17,6 +17,6 @@ jobs:
       run: |
         npm ci
         npm run doc
-        npx gh-pages -d docs -u "haribote <haribote.nobody@gmail.com>"  -r https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+        npx gh-pages -d docs -u ${{ secrets.PUBLISH_GH_PAGES_USER }}  -r https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
       env:
         CI: true

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -17,6 +17,6 @@ jobs:
       run: |
         npm ci
         npm run doc
-        npx gh-pages -d docs -r https://${{ secrets.GITHUB_TOKEN }}@github.com/maboroshi-inc/selector.git -u "haribote <haribote.nobody@gmail.com>"
+        npx gh-pages -d docs -u "haribote <haribote.nobody@gmail.com>" -r "https://${{ secrets.GITHUB_TOKEN }}@github.com/maboroshi-inc/selector.git"
       env:
         CI: true

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -17,6 +17,6 @@ jobs:
       run: |
         npm ci
         npm run doc
-        npx gh-pages -d docs -u ${{ secrets.PUBLISH_GH_PAGES_USER }}  -r https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+        npx gh-pages -d docs -u "${{ secrets.PUBLISH_GH_PAGES_USER }}"  -r "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
       env:
         CI: true


### PR DESCRIPTION
バージョニングタグが付けられたら実行されるPost-Releaseワークフローを設定する。

- [x] `gh-pages` によるドキュメントのデプロイ機能の実装
- [ ] `typedoc` を `npx` で実行するように変更
- [ ] ワークフローの実行トリガーをバージョニングタグの `push` に設定
