### PR TITLE
Deployワークフローを設定する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: deploy document
+      - name: npm install, deploy document
         run: |
+          npm ci
           npx typedoc --out ./docs --mode file --ignoreCompilerErrors --theme minimal
           npx gh-pages -d docs -u "${{ secrets.PUBLISH_GH_PAGES_USER }}"  -r "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,15 @@
+name: Deploy
+
+on: push
+
+jobs:
+  test
+    name: check version
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,15 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: check version
+      - name: npm install, lint, type-check, test, and version-cehck
         run: |
+          npm ci
+          npm run lint
+          npx tsc --noEmit
+          npm test -- --ci
           npx can-npm-publish --verbose
+        env:
+          CI: true
 
   publish:
     name: publish to npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,3 +34,5 @@ jobs:
           npm ci
           npx typedoc --out ./docs --mode file --ignoreCompilerErrors --theme minimal
           npx gh-pages -d docs -u "${{ secrets.PUBLISH_GH_PAGES_USER }}"  -r "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+        env:
+          CI: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Deploy
 
-on: push
+on:
+  release:
+    types: [created]
 
 jobs:
   test:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,26 @@ jobs:
         run: |
           npx can-npm-publish --verbose
 
+  publish:
+    name: publish to npm
+
+    needs: [test]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: npm install, publish
+        run: |
+          npm ci
+          npm publish
+        env:
+          CI: true
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
   deploy:
     name: post-process to publish
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,3 +16,20 @@ jobs:
       - name: check version
         run: |
           npx can-npm-publish --verbose
+
+  deploy:
+    name: post-process to publish
+
+    needs: [test]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: deploy document
+        run: |
+          npx typedoc --out ./docs --mode file --ignoreCompilerErrors --theme minimal
+          npx gh-pages -d docs -u "${{ secrets.PUBLISH_GH_PAGES_USER }}"  -r "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+          registry-url: https://registry.npmjs.org/
       - name: npm install
         run: npm ci
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,15 +15,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: npm install, lint, type-check, test, and version-cehck
-        run: |
-          npm ci
-          npm run lint
-          npx tsc --noEmit
-          npm test -- --ci
-          npx can-npm-publish --verbose
-        env:
-          CI: true
+      - name: version-cehck
+        run: npx can-npm-publish --verbose
 
   publish:
     name: publish to npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,4 +15,4 @@ jobs:
           node-version: '12.x'
       - name: check version
         run: |
-          npx can-npm-publish -- --verbose
+          npx can-npm-publish --verbose

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@ name: Deploy
 on: push
 
 jobs:
-  test
-    name: check version
+  test:
+    name: pre-process to publish
 
     runs-on: ubuntu-latest
 
@@ -13,3 +13,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+      - name: check version
+        run: |
+          npx can-npm-publish -- --verbose

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   test:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,13 +37,14 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: npm install, publish
-        run: |
-          npm ci
-          npm publish
+      - name: npm install
+        run: npm ci
         env:
           CI: true
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: npm publish
+        run: npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   deploy:
     name: post-process to publish

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -1,6 +1,9 @@
 name: Pre-Merge
 
-on: push
+on:
+  push:
+    branches-ignore:
+      - master
 
 jobs:
   test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1017,15 +1017,6 @@
         "babel-plugin-jest-hoist": "^24.9.0"
       }
     },
-    "backbone": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-      "dev": true,
-      "requires": {
-        "underscore": ">=1.8.3"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -3498,12 +3489,6 @@
         }
       }
     },
-    "highlight.js": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.16.2.tgz",
-      "integrity": "sha512-feMUrVLZvjy0oC7FVJQcSQRqbBq9kwqnYE4+Kj9ZjbHh3g+BisiPgF49NyQbVLNdrL/qqZr3Ca9yOKwgn2i/tw==",
-      "dev": true
-    },
     "hosted-git-info": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
@@ -3782,12 +3767,6 @@
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
       }
-    },
-    "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-      "dev": true
     },
     "invariant": {
       "version": "2.2.4",
@@ -4578,12 +4557,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5258,12 +5231,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lunr": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
-      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
-      "dev": true
-    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -5317,12 +5284,6 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
-    },
-    "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
-      "dev": true
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -6006,15 +5967,6 @@
         "util.promisify": "^1.0.0"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -6396,17 +6348,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
-    },
-    "shelljs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
     },
     "shellwords": {
       "version": "0.1.1",
@@ -7195,45 +7136,6 @@
       "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
       "dev": true
     },
-    "typedoc": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.0.tgz",
-      "integrity": "sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "3.0.3",
-        "fs-extra": "^8.1.0",
-        "handlebars": "^4.1.2",
-        "highlight.js": "^9.15.8",
-        "lodash": "^4.17.15",
-        "marked": "^0.7.0",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "shelljs": "^0.8.3",
-        "typedoc-default-themes": "^0.6.0",
-        "typescript": "3.5.x"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "3.5.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-          "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
-          "dev": true
-        }
-      }
-    },
-    "typedoc-default-themes": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.0.tgz",
-      "integrity": "sha512-MdTROOojxod78CEv22rIA69o7crMPLnVZPefuDLt/WepXqJwgiSu8Xxq+H36x0Jj3YGc7lOglI2vPJ2GhoOybw==",
-      "dev": true,
-      "requires": {
-        "backbone": "^1.4.0",
-        "jquery": "^3.4.1",
-        "lunr": "^2.3.6",
-        "underscore": "^1.9.1"
-      }
-    },
     "typescript": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
@@ -7250,12 +7152,6 @@
         "commander": "~2.20.3",
         "source-map": "~0.6.1"
       }
-    },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-      "dev": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,10 @@
   ],
   "scripts": {
     "build": "rollup -c",
-    "doc": "typedoc --out ./docs --mode file --ignoreCompilerErrors --theme minimal",
     "lint": "eslint src/**/*.ts __tests__/**/*.ts",
     "lint:fix": "npm run lint -- --fix",
     "prepublishOnly": "npm run lint && npm run test && npm run build",
-    "release": "release-it --no-npm.publish",
-    "test": "jest --coverage"
+    "test": "jest"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/selector",
-  "version": "1.0.5",
+  "version": "1.0.5-rc.0",
   "description": "Just aliases of querySelector.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/selector",
-  "version": "1.0.5-rc.1",
+  "version": "1.0.5-rc.2",
   "description": "Just aliases of querySelector.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "rollup-plugin-progress": "^1.1.1",
     "rollup-plugin-typescript2": "^0.24.1",
     "ts-jest": "^24.0.2",
-    "typedoc": "^0.15.0",
     "typescript": "^3.5.1"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/selector",
-  "version": "1.0.5-rc.3",
+  "version": "1.0.5",
   "description": "Just aliases of querySelector.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/selector",
-  "version": "1.0.5-rc.0",
+  "version": "1.0.5-rc.1",
   "description": "Just aliases of querySelector.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/selector",
-  "version": "1.0.5",
+  "version": "1.0.4",
   "description": "Just aliases of querySelector.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/selector",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Just aliases of querySelector.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maboroshi/selector",
-  "version": "1.0.5-rc.2",
+  "version": "1.0.5-rc.3",
   "description": "Just aliases of querySelector.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
GitHubのリリース機能を使ってパッケージをnpmに公開するためのワークフローを設定します。

- [x] `release.published` イベントをトリガーに設定する
- [x] npm にリリースできるかを判定する機能を設定する
- [x] `npm publish` するジョブを設定する
- [x] ドキュメントをデプロイするジョブを設定する
